### PR TITLE
Changed postgres user env var to same as in the postgres image

### DIFF
--- a/scripts/config_gen.sh
+++ b/scripts/config_gen.sh
@@ -13,7 +13,7 @@ BACKUP_USER=
 HOSTNAME=${POSTGRES_HOSTNAME}
  
 # Optional username to connect to database as.  Will default to "postgres" if none specified.
-USERNAME=${POSTGRES_USERNAME-postgres}
+USERNAME=${POSTGRES_USER-postgres}
  
 # This dir will be created if it doesn't exist.  This must be writable by the user the script is
 # running as.


### PR DESCRIPTION
To avoid duplicate env vars in the env file.